### PR TITLE
Add game launch error handling

### DIFF
--- a/LaunchernoNakuKoroni/MainWindow.xaml.cs
+++ b/LaunchernoNakuKoroni/MainWindow.xaml.cs
@@ -33,27 +33,52 @@ namespace LaunchernoNakuKoroni
             InitializeComponent();
         }
 
-        private void ButtonHigQ1_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("HigQ1_exe"));
-        private void ButtonHigQ2_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("HigQ2_exe"));
-        private void ButtonHigQ3_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("HigQ3_exe"));
-        private void ButtonHigQ4_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("HigQ4_exe"));
-        private void ButtonHigA1_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("HigA1_exe"));
-        private void ButtonHigA2_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("HigA2_exe"));
-        private void ButtonHigA3_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("HigA3_exe"));
-        private void ButtonHigA4_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("HigA4_exe"));
-        private void ButtonHigRei_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("HigRei_exe"));
-        private void ButtonHigHou_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("HigHou_exe"));
-        private void ButtonHigCon_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("HigCon_exe"));
-        private void ButtonUmiQ_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("UmiQ_exe"));
-        private void ButtonUmiA_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("UmiA_exe"));
-        private void ButtonUmiT_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("UmiT_exe"));
-        private void ButtonUmiH_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("UmiH_exe"));
-        private void ButtonUmiS_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("UmiS_exe"));
-        private void ButtonCic1_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("Cic1_exe"));
-        private void ButtonCic2_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("Cic2_exe"));
-        private void ButtonCic3_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("Cic3_exe"));
-        private void ButtonCic4_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("Cic4_exe"));
-        private void ButtonUmi07T_Click(object sender, RoutedEventArgs e) => System.Diagnostics.Process.Start(ConfigurationManager.AppSettings.Get("Umi07T_exe"));
+        private void LaunchGame(string gameName)
+        {
+            string path = ConfigurationManager.AppSettings[gameName];
+            if (path == null)
+            {
+                MessageBox.Show($"Error: Can't find [{gameName}]'s path in App Settings!\nPlease make sure it is defined in the config file.", "Game not in app settings");
+                return;
+            }
+
+            if (!System.IO.File.Exists(path)
+            {
+                MessageBox.Show($"Error: Game [{gameName}] couldn't be found at [{path}].\nPlease check the path is correct in the config file.", "Game path incorrect");
+                return;
+            }
+
+            try
+            {
+                System.Diagnostics.Process.Start(path);
+            }
+            catch (Exception e)
+            {
+                MessageBox.Show($"Error: Can't start game [{gameName}] at [{path}] due to unknown error:\n\n{e.ToString()}", "Can't start game");
+            }
+        }
+
+        private void ButtonHigQ1_Click(object sender, RoutedEventArgs e) => LaunchGame("HigQ1_exe");
+        private void ButtonHigQ2_Click(object sender, RoutedEventArgs e) => LaunchGame("HigQ2_exe");
+        private void ButtonHigQ3_Click(object sender, RoutedEventArgs e) => LaunchGame("HigQ3_exe");
+        private void ButtonHigQ4_Click(object sender, RoutedEventArgs e) => LaunchGame("HigQ4_exe");
+        private void ButtonHigA1_Click(object sender, RoutedEventArgs e) => LaunchGame("HigA1_exe");
+        private void ButtonHigA2_Click(object sender, RoutedEventArgs e) => LaunchGame("HigA2_exe");
+        private void ButtonHigA3_Click(object sender, RoutedEventArgs e) => LaunchGame("HigA3_exe");
+        private void ButtonHigA4_Click(object sender, RoutedEventArgs e) => LaunchGame("HigA4_exe");
+        private void ButtonHigRei_Click(object sender, RoutedEventArgs e) => LaunchGame("HigRei_exe");
+        private void ButtonHigHou_Click(object sender, RoutedEventArgs e) => LaunchGame("HigHou_exe");
+        private void ButtonHigCon_Click(object sender, RoutedEventArgs e) => LaunchGame("HigCon_exe");
+        private void ButtonUmiQ_Click(object sender, RoutedEventArgs e) => LaunchGame("UmiQ_exe");
+        private void ButtonUmiA_Click(object sender, RoutedEventArgs e) => LaunchGame("UmiA_exe");
+        private void ButtonUmiT_Click(object sender, RoutedEventArgs e) => LaunchGame("UmiT_exe");
+        private void ButtonUmiH_Click(object sender, RoutedEventArgs e) => LaunchGame("UmiH_exe");
+        private void ButtonUmiS_Click(object sender, RoutedEventArgs e) => LaunchGame("UmiS_exe");
+        private void ButtonCic1_Click(object sender, RoutedEventArgs e) => LaunchGame("Cic1_exe");
+        private void ButtonCic2_Click(object sender, RoutedEventArgs e) => LaunchGame("Cic2_exe");
+        private void ButtonCic3_Click(object sender, RoutedEventArgs e) => LaunchGame("Cic3_exe");
+        private void ButtonCic4_Click(object sender, RoutedEventArgs e) => LaunchGame("Cic4_exe");
+        private void ButtonUmi07T_Click(object sender, RoutedEventArgs e) => LaunchGame("Umi07T_exe");
 
     }
 }


### PR DESCRIPTION
Add error handling for 

1. missing .exe in config
2. .exe doesn't exist at given path
3. an unknown error during .exe launch

Note that if an exception happens in WPF, the default behavior is to silently close the whole application. There are ways around this, like adding a global exception handler to the program. For example: https://stackoverflow.com/a/35753915/848627 . Note that in that example, it doesn't attempt to shutdown the program after displaying the error message to the user - you should definitely do that as after an unknown error, it can be difficult to tell whether the program can operate properly afterwards.